### PR TITLE
Bug fix posthog - identify not working for subscription

### DIFF
--- a/.turbo/turbo-build.log
+++ b/.turbo/turbo-build.log
@@ -1,0 +1,30 @@
+
+
+> blog@0.1.0 build /home/tyro23006/lmnas-turbo/apps/braccoli-bites
+> next build
+
+   [1m[38;2;173;127;168m▲ Next.js 15.1.11[39m[22m
+   - Environments: .env
+
+ [37m[1m [22m[39m Creating an optimized production build ...
+ [32m[1m✓[22m[39m Compiled successfully
+[?25l [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m...[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m...[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m...[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m...[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m...[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m.[39m[2K[1G [37m[1m [22m[39m Linting and checking validity of types  [36m..[39m[2K[1G[?25h [37m[1m [22m[39m Linting and checking validity of types     [32m[1m✓[22m[39m Linting and checking validity of types 
+[?25l [37m[1m [22m[39m Collecting page data  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting page data  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting page data  [36m...[39m[2K[1G[?25h [37m[1m [22m[39m Collecting page data     [32m[1m✓[22m[39m Collecting page data 
+[?25l [37m[1m [22m[39m Generating static pages (0/3)  [36m[    ][39m[2K[1G [37m[1m [22m[39m Generating static pages (0/3)  [36m[=   ][39m[2K[1G[?25h [32m[1m✓[22m[39m Generating static pages (3/3)
+[?25l [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[?25l [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m.[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m.[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m..[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m..[39m[2K[1G [37m[1m [22m[39m Finalizing page optimization  [36m...[39m[2K[1G [37m[1m [22m[39m Collecting build traces  [36m...[39m[2K[1G[?25h [37m[1m [22m[39m Collecting build traces     [32m[1m✓[22m[39m Collecting build traces 
+[2K[1G[?25h [37m[1m [22m[39m Finalizing page optimization     [32m[1m✓[22m[39m Finalizing page optimization 
+
+[4mRoute (app)[24m                              [4mSize[24m     [4mFirst Load JS[24m
+┌ ○ /_not-found                          986 B           [37m[1m107 kB[22m[39m
+├ ƒ /[locale]                            3.34 kB         [37m[1m127 kB[22m[39m
+└ ƒ /[locale]/[slug]                     1.82 kB         [37m[1m121 kB[22m[39m
++ First Load JS shared by all            [37m[1m106 kB[22m[39m
+  ├ chunks/4ba5fc05-82cdb2873ecabac8.js  53 kB
+  ├ chunks/631-a8548cb9c946af2f.js       50.8 kB
+  └ other shared chunks (total)          2.06 kB
+
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+
+[?25h

--- a/.turbo/turbo-start.log
+++ b/.turbo/turbo-start.log
@@ -1,26 +1,10 @@
 
-> blog@0.1.0 start /home/yuvaraj/Desktop/lmnas-turbo/apps/braccoli-bites
+> blog@0.1.0 start /home/tyro23006/lmnas-turbo/apps/braccoli-bites
 > next start -p 3001
 
    [1m[38;2;173;127;168m▲ Next.js 15.1.11[39m[22m
    - Local:        http://localhost:3001
-   - Network:      http://10.220.107.80:3001
+   - Network:      http://192.168.1.52:3001
 
  [32m[1m✓[22m[39m Starting...
- [32m[1m✓[22m[39m Ready in 316ms
- [31m[1m⨯[22m[39m Error: Meta data not found for blog slug: sample-version-2.0
-    at Module.sk (.next/server/app/[locale]/[slug]/page.js:1:325556) {
-  digest: [32m'459584758'[39m
-}
- [31m[1m⨯[22m[39m TypeError: Cannot read properties of null (reading 'schemaData')
-    at sC (.next/server/app/[locale]/[slug]/page.js:1:325717) {
-  digest: [32m'4278677333'[39m
-}
- [31m[1m⨯[22m[39m Error: Meta data not found for blog slug: sample-version-04
-    at Module.sk (.next/server/app/[locale]/[slug]/page.js:1:325556) {
-  digest: [32m'4260613302'[39m
-}
- [31m[1m⨯[22m[39m TypeError: Cannot read properties of null (reading 'schemaData')
-    at sC (.next/server/app/[locale]/[slug]/page.js:1:325717) {
-  digest: [32m'4278677333'[39m
-}
+ [32m[1m✓[22m[39m Ready in 273ms

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -15,6 +15,8 @@ import {
   TnavbarTarget,
   TseoIcons,
 } from "@repo/middleware/types";
+import NewsletterIdentifyListener from "@/components/newsletter-identify-listener";
+import ClientLayout from "@/components/client-layout";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -120,12 +122,13 @@ export default async function RootLayout({
         >
           <Navbar idNavbar={LdnavbarData} />
           <main className="">
-            {/* <ClientLayout> */}
+            <ClientLayout>
             {children}
-            {/* </ClientLayout> */}
+            </ClientLayout>
           </main>
           <Footer idFooter={LdfooterData} />
         </ThemeProvider>
+        <NewsletterIdentifyListener />
         <ChatInit />
       </body>
     </html>

--- a/components/client-layout.tsx
+++ b/components/client-layout.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect } from "react";
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+            api_host: "/ingest",
+            ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+            defaults: "2026-01-30",
+            capture_exceptions: true,
+            debug: process.env.NODE_ENV === "development",
+        });
+    }, []);
+    return <>{children}</>
+}

--- a/components/client-layout.tsx
+++ b/components/client-layout.tsx
@@ -4,6 +4,7 @@ import posthog from "posthog-js";
 import { useEffect } from "react";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
+    // Initializing PostHog
     useEffect(() => {
         posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
             api_host: "/ingest",

--- a/components/newsletter-identify-listener.tsx
+++ b/components/newsletter-identify-listener.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect } from "react"
+import { identifyPostHogFormSubmitter } from "../lib/posthog-identify"
+
+type TNewsletterSubscribedEvent = CustomEvent<{
+  email?: string
+  status?: "subscribed" | "already_subscribed" | "error"
+}>
+
+export default function NewsletterIdentifyListener() {
+  useEffect(() => {
+    const fnHandleNewsletterSubscribed = (iEvent: Event) => {
+      const LdEvent = iEvent as TNewsletterSubscribedEvent
+
+      // commented this out, to
+      // Temporarily identify users based only on email presence.
+      // This is a diagnostic change to verify whether the status-based
+      // success check is preventing some newsletter subscribers from
+      // being identified in PostHog.
+      // if (
+      //   !LdEvent.detail?.email ||
+      //   !["subscribed", "already_subscribed"].includes(LdEvent.detail.status ?? "error")
+      // ) {
+      //   return
+      // }
+      if (!LdEvent.detail?.email) {
+        return
+      }  
+
+      identifyPostHogFormSubmitter(
+        { email: LdEvent.detail.email },
+        {
+          formId: "newsletter",
+          formSource: "footer_newsletter",
+          formTitle: "Footer newsletter",
+          newsletterOptIn: true,
+        },
+      )
+    }
+
+    window.addEventListener("newsletter_subscribed", fnHandleNewsletterSubscribed)
+
+    return () => {
+      window.removeEventListener("newsletter_subscribed", fnHandleNewsletterSubscribed)
+    }
+  }, [])
+
+  return null
+}

--- a/components/subscription.tsx
+++ b/components/subscription.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { type ReactElement, useActionState, useEffect } from "react";
+import { type ReactElement, useActionState } from "react";
 import { Button } from "@repo/ui/components/ui/button";
 import { Input } from "@repo/ui/components/ui/input";
 import {
@@ -24,24 +24,28 @@ export function NewsletterSubscription({
     LdInitialState,
   );
 
-  useEffect(() => {
-    if (
-      typeof window === "undefined" ||
-      !state.email ||
-      !["subscribed", "already_subscribed"].includes(state.status)
-    ) {
-      return;
-    }
+   // Previous implementation dispatched the newsletter_subscribed event
+  // only after receiving a successful server action response.
+  // Temporarily disabled for investigation because some production users
+  // appear to subscribe successfully but never trigger PostHog identify.
+  // We now dispatch the event immediately on form submission to determine
+  // whether the server-response flow is causing identify events to be missed.
+  // useEffect(() => {
+  //   if (
+  //     typeof window === "undefined" ||
+  //     !LdState.email ||
+  //     !["subscribed", "already_subscribed"].includes(LdState.status)
+  //   ) {
+  //     return
+  //   }
 
-    window.dispatchEvent(
-      new CustomEvent("newsletter_subscribed", {
-        detail: {
-          email: state.email,
-          status: state.status,
-        },
-      }),
-    );
-  }, [state.email, state.status]);
+  //   window.dispatchEvent(
+  //     new CustomEvent("newsletter_subscribed", {
+  //       detail: { email: LdState.email, status: LdState.status },
+  //     }),
+  //   )
+  // }, [LdState.email, LdState.status])
+
 
   return (
     <section className="w-full py-6">
@@ -51,6 +55,24 @@ export function NewsletterSubscription({
             <form
               action={formAction}
               className="flex flex-col gap-4 sm:flex-row sm:items-center"
+              onSubmit={(e) => {
+                // Dispatch the newsletter_subscribed event immediately when the user
+                // submits the form. This bypasses the dependency on the server action
+                // response and helps verify whether delayed or missing responses are
+                // preventing PostHog user identification for some subscribers.
+                const LdFormData = new FormData(e.currentTarget)
+                const LEmail = LdFormData.get("email")
+            
+                if (typeof LEmail === "string" && LEmail.trim()) {
+                  window.dispatchEvent(
+                    new CustomEvent("newsletter_subscribed", {
+                      detail: {
+                        email: LEmail.trim().toLowerCase(),
+                      },
+                    }),
+                  )
+                }
+              }}
             >
               <Input
                 type="email"

--- a/lib/posthog-identify.ts
+++ b/lib/posthog-identify.ts
@@ -1,0 +1,73 @@
+"use client"
+
+import posthog from "posthog-js"
+
+type TIdentifyContext = {
+  formId: string
+  formTitle?: string
+  formSource: string
+  lastCaseStudyName?: string
+  newsletterOptIn?: boolean
+}
+
+type TIdentifyFormData = {
+  email?: unknown
+  name?: unknown
+  phone?: unknown
+}
+
+const fnNormalizeEmail = (iEmail?: unknown) => {
+  if (typeof iEmail !== "string") return null
+
+  const LEmail = iEmail.trim().toLowerCase()
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(LEmail) ? LEmail : null
+}
+
+const fnStringProperty = (iValue?: unknown) => {
+  if (typeof iValue !== "string") return undefined
+
+  const LValue = iValue.trim()
+  return LValue || undefined
+}
+
+export function identifyPostHogFormSubmitter(
+  idFormData: TIdentifyFormData,
+  idContext: TIdentifyContext,
+) {
+  const LEmail = fnNormalizeEmail(idFormData.email)
+
+  if (!LEmail) return
+
+  const LSubmittedAt = new Date().toISOString()
+  const LSetProperties: Record<string, unknown> = {
+    email: LEmail,
+    last_form_id: idContext.formId,
+    last_form_source: idContext.formSource,
+    last_submitted_at: LSubmittedAt,
+  }
+
+  const LName = fnStringProperty(idFormData.name)
+  const LPhone = fnStringProperty(idFormData.phone)
+  const LFormTitle = fnStringProperty(idContext.formTitle)
+  const LCaseStudyName = fnStringProperty(idContext.lastCaseStudyName)
+
+  if (LName) LSetProperties.name = LName
+  if (LPhone) LSetProperties.phone = LPhone
+  if (LFormTitle) LSetProperties.last_form_title = LFormTitle
+  if (LCaseStudyName) LSetProperties.last_case_study_name = LCaseStudyName
+  if (idContext.newsletterOptIn) LSetProperties.newsletter_opt_in = true
+
+  const LSetOnceProperties: Record<string, unknown> = {
+    first_form_id: idContext.formId,
+    first_form_source: idContext.formSource,
+    first_submitted_at: LSubmittedAt,
+  }
+
+  if (LCaseStudyName) LSetOnceProperties.first_case_study_name = LCaseStudyName
+
+  posthog.identify(
+    LEmail,
+    LSetProperties,
+    LSetOnceProperties,
+  )
+}

--- a/lib/posthog-identify.ts
+++ b/lib/posthog-identify.ts
@@ -15,7 +15,7 @@ type TIdentifyFormData = {
   name?: unknown
   phone?: unknown
 }
-
+// Normalize an email address and verify its format
 const fnNormalizeEmail = (iEmail?: unknown) => {
   if (typeof iEmail !== "string") return null
 
@@ -23,6 +23,7 @@ const fnNormalizeEmail = (iEmail?: unknown) => {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(LEmail) ? LEmail : null
 }
 
+// Trim string values and discard empty inputs
 const fnStringProperty = (iValue?: unknown) => {
   if (typeof iValue !== "string") return undefined
 
@@ -30,10 +31,12 @@ const fnStringProperty = (iValue?: unknown) => {
   return LValue || undefined
 }
 
+// Identify and associate form submitters with PostHog user profiles
 export function identifyPostHogFormSubmitter(
   idFormData: TIdentifyFormData,
   idContext: TIdentifyContext,
 ) {
+  // Normalize and validate the submitted email address
   const LEmail = fnNormalizeEmail(idFormData.email)
 
   if (!LEmail) return
@@ -46,25 +49,30 @@ export function identifyPostHogFormSubmitter(
     last_submitted_at: LSubmittedAt,
   }
 
+  // Extract and sanitize optional form fields
   const LName = fnStringProperty(idFormData.name)
   const LPhone = fnStringProperty(idFormData.phone)
   const LFormTitle = fnStringProperty(idContext.formTitle)
   const LCaseStudyName = fnStringProperty(idContext.lastCaseStudyName)
 
+  // Add optional user and form metadata when available
   if (LName) LSetProperties.name = LName
   if (LPhone) LSetProperties.phone = LPhone
   if (LFormTitle) LSetProperties.last_form_title = LFormTitle
   if (LCaseStudyName) LSetProperties.last_case_study_name = LCaseStudyName
   if (idContext.newsletterOptIn) LSetProperties.newsletter_opt_in = true
 
+  // Store first-submission properties only once for the user
   const LSetOnceProperties: Record<string, unknown> = {
     first_form_id: idContext.formId,
     first_form_source: idContext.formSource,
     first_submitted_at: LSubmittedAt,
   }
 
+  // Record the first downloaded case study for attribution
   if (LCaseStudyName) LSetOnceProperties.first_case_study_name = LCaseStudyName
 
+  // Identify the user and persist profile properties in PostHog
   posthog.identify(
     LEmail,
     LSetProperties,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@tailwindcss/typography": "^0.5.19",
     "clsx": "^2.1.1",
     "lucide-react": "^0.474.0",
+    "posthog-js": "^1.372.10",
+    "posthog-node": "^5.33.4",
     "next": "15.1.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
Improved newsletter subscriber identification for PostHog by dispatching the identification event immediately on form submission instead of waiting for the newsletter server action response.

**Change Object:**
- app/[locale]/layout.tsx
- components/client-layout.tsx
- components/newsletter-identify-listener.tsx
- components/subscription.tsx
- lib/posthog-identify.ts
- package.json